### PR TITLE
Use admin user in relevant background processes when deleting

### DIFF
--- a/html/primes/support/connect_db.pm
+++ b/html/primes/support/connect_db.pm
@@ -3,6 +3,7 @@ package connect_db;
 # Connects to the primes database.  Functions:
 #
 # connect([{database=>$database, user=>$user, password=>$password}])
+# connect_admin([{database=>$database}])
 #	Connects and returns a database handle (uses old one if previously connected)
 #	Note: we can not switch between bases
 #
@@ -57,6 +58,13 @@ sub connect {
 
 #  }
   return $dbh;
+}
+
+sub connect_admin {
+  my $s = shift || {};
+  $$s{'user'} = 'primes_admin';
+  $$s{'password'} = environment::T5K_DB_PRIMES_ADMIN_PASSWORD;
+  return &connect_db::connect($s);
 }
 
 sub UpdateRow {

--- a/html/primes/support/remove
+++ b/html/primes/support/remove
@@ -31,7 +31,7 @@ $opt_t and print "Test mode: will not alter the database, mail written to ".
 
 # Open database handle
 
-my $dbh = &connect_db::connect();
+my $dbh = &connect_db::connect_admin(); #deleting rows is more dangerous, therefore needs more security
 
 # First, for the log and to email, make a list of the id's being removed
 

--- a/html/primes/support/remove_unused_codes
+++ b/html/primes/support/remove_unused_codes
@@ -55,7 +55,7 @@ if (not $opt_w) { # $opt_w overrides the age limit
 # Open database handle
 
 use connect_db;
-my $dbh = &connect_db::connect();
+my $dbh = &connect_db::connect_admin(); #deleting rows is more dangerous, therefore needs more security
 $opt_s or print "Connected to database.\n";
 
 # Get a list of the codes to remove (display_html will be used when logging the deletion)

--- a/html/primes/support/remove_unused_persons
+++ b/html/primes/support/remove_unused_persons
@@ -49,7 +49,7 @@ if ($opt_n and  $opt_n =~ /^\d+$/) {
 # Open database handle
 
 use connect_db;
-my $dbh = &connect_db::connect();
+my $dbh = &connect_db::connect_admin(); #deleting rows is more dangerous, therefore needs more security
 $opt_s or print "Connected to database.\n";
 
 # Get a list of the persons to remove (display_html will be used when logging the deletion)


### PR DESCRIPTION
Avoids needing to give the commonly used `primes_` user more permissions, which is nice considering how many user-facing places that user is used.