### PR TITLE
Fix minor issues with crackpot page

### DIFF
--- a/html/notes/crackpot.html
+++ b/html/notes/crackpot.html
@@ -11,9 +11,9 @@
   <!-- #EndEditable --> <!-- #BeginEditable "description" -->
   <meta name="description" content="A simple guide to the evaluation of contribution to the PrimeNumbers 
         list. Though this index is formed partly as a joke, in it 
-        are serious signs that one can use to recognize a crack-pot.&nbsp; Some 
+        are serious signs that one can use to recognize a crackpot.&nbsp; Some
         novice (and mathematically unsophisticated) members on the list can be 
-        taken in by crack-pot claims.&nbsp; We'd like to stop such posts and 
+        taken in by crackpot claims.&nbsp; We'd like to stop such posts and
         claims from spreading like a virus.">
   <!-- #EndEditable -->
   <!-- PrimePage icon -->
@@ -114,17 +114,17 @@
       <h3 class="mt-n3 mb-3 p-2 pl-4 rounded blue lighten-4">By Chris Caldwell</h3>
       <!-- #BeginEditable "content" -->
       <p>(Adapted from <a href="http://math.ucr.edu/home/baez/crackpot.html">an
-          index</a>for Physics Claims by John Baez.)</p>
+          index</a> for Physics Claims by John Baez.)</p>
       <p> A simple guide to the evaluation of contribution to the <a
           href="http://groups.yahoo.com/group/primenumbers/">PrimeNumbers
           list</a>.&nbsp; Though this index is formed <em>partly</em> as a joke,
-        in it are serious signs that one can use to recognize a crack-pot.&nbsp; Some
+        in it are serious signs that one can use to recognize a crackpot.&nbsp; Some
         novice and mathematically unsophisticated members on the list can
-        be taken in by crack-pot claims.&nbsp; We'd like to stop such posts
+        be taken in by crackpot claims.&nbsp; We'd like to stop such posts
         and claims from spreading like a virus.
       <p>When you do recognize such claims, it is usually best not to respond.&nbsp; When you do respond, do so with
         gentleness and respect.&nbsp; A flame
-        war is as much an annoyance on the list as a crack-pot's droning.</p>
+        war is as much an annoyance on the list as a crackpot's droning.</p>
       <h2>Credits (evidence of reasonableness)</h2>
       <ol>
         <li>Subtract 5 points for each refereed publication in a closely related
@@ -135,7 +135,6 @@
       <h2>Debits (evidence of 'crackpot'ness)</h2>
       <ul>
         <li class="pt-3"><b>Syntax</b><br>
-        </li>
         <ol>
           <li>1 point for each word in all capital letters.</li>
           <li>5 points for every statement that is clearly vacuous, logically
@@ -146,8 +145,8 @@
           <li>10 points for each new term you invent or use without properly defining
             it.</li>
         </ol>
-        <li class="pt-3"><b>Subject and Claims</b><br>
         </li>
+        <li class="pt-3"><b>Subject and Claims</b><br>
         <ol start="6">
           <li>5 points for offering prize money to anyone who proves and/or finds
             any flaws in your theory. (<a href="#but">*</a>) </li>
@@ -157,7 +156,7 @@
             purport to have solved: Goldbach's conjecture; twin prime conjecture;
             Riemann Hypothesis, GRH; Fermat's Last Theorem (<a href="#but">*</a>);
             infinitely many Mersennes, Fermats, primes
-            of the form <i>n</i><sup>2</sup>+1...; or finding new patterns in
+            of the form <var>n</var><sup>2</sup>+1...; or finding new patterns in
             the primes.</li>
           <li>20 points for talking about how great your theory is, but never
             actually explaining it.</li>
@@ -166,8 +165,8 @@
             the problem. <br>
           </li>
         </ol>
-        <li class="pt-3"><b>Hubris</b><br>
         </li>
+        <li class="pt-3"><b>Hubris</b><br>
         <ol start="11">
           <li>10 points for pointing out that you have gone to school, as if this
             were evidence of sanity. </li>
@@ -183,8 +182,8 @@
             the "Caldwell primes" or "the Caldwell factorizer" when your name happens
             to be Caldwell.) </li>
         </ol>
-        <li class="pt-3"><b>Process and Proof</b><br>
         </li>
+        <li class="pt-3"><b>Process and Proof</b><br>
         <ol start="17">
           <li>10 points for expecting others to disprove your result(s) rather
             than providing the proof yourself. </li>
@@ -198,8 +197,8 @@
             well established crackpots.</li>
           <li>50 points for failing to respond to appropriate corrections, questions and challenges. </li>
         </ol>
-        <li class="pt-3"><b>Whining</b><br>
         </li>
+        <li class="pt-3"><b>Whining</b><br>
         <ol start="23">
           <li>10 points for expressing fear that your ideas will be stolen. </li>
           <li>15 points for complaining about the existence of this crackpot index.
@@ -217,9 +216,10 @@
             are engaged in a "conspiracy" to prevent your work from gaining its
             well-deserved recognition or fame. </li>
         </ol>
+        </li>
       </ul>
       <h2>Additional Comments </h2>
-      <h3><a name="values"></a>Point Values </h3>
+      <h3 id="values">Point Values </h3>
       <p>I have tried to place the highest penalties on those behaviors which most
         directly contradict the methods of mathematics.&nbsp; <b>In
           mathematics we seek to communicate and share.</b>&nbsp; This starts by studying
@@ -235,7 +235,7 @@
       <p>Mathematical communication then continues
         by listening.&nbsp; Mathematicians share their results as preprints and <a
           href="http://www.ams.org/meetings/">at
-          meetings</a>so that others can see what they are doing and so that the authors
+          meetings</a> so that others can see what they are doing and so that the authors
         might gain from the feedback.&nbsp; Mathematical
         disagreements and times arise but they are addressed in the time honored
         way: put up or shut up.&nbsp; That is, either present a proof of your position
@@ -246,7 +246,7 @@
         is a conversation, not a soliloquy.&nbsp; Crackpots are unable to listen,
         unable to join into this conversation.&nbsp; In fact most crackpots set themselves
         in direct opposition to the dialog of mathematics. </p>
-      <h3><a name="establish"></a>Establishing Claim </h3>
+      <h3 id="establish">Establishing Claim </h3>
       <p>How do mathematicians establish claim to their ideas?&nbsp; <a href="/notes/faq/publish.html">They
           publish</a>.&nbsp; Eventually
         in a journal, but usually first by e-mail, preprints and at mathematical conventions.&nbsp; Many
@@ -259,7 +259,7 @@
         the idea may be lost.&nbsp; In
         mathematics you establish your claim by sharing your proof (correctly, concisely,
         in the appropriate locations).&nbsp;</p>
-      <h3><a name="but"></a>But what about... </h3>
+      <h3 id="but">But what about... </h3>
       <p>Some of the behaviors attributed to crackpots are also present in the elder
         statesmen of mathematics.&nbsp; For example, Paul Erd&ouml;s famously offered
         prizes for proofs (and disproofs) of those things he thought true.&nbsp; Before
@@ -267,7 +267,7 @@
         continue to pay on most of his offers).&nbsp; But Erd&ouml;s' mathematical
         saneness is well established by the 1500+ papers he wrote or coauthored.&nbsp; Indeed
         it is these articles that established his right to offer prizes.</p>
-      <p>Another excellent example is Andre Wiles who proved Fermat's Last Theorem
+      <p>Another excellent example is Andrew Wiles who proved Fermat's Last Theorem
         (FLT).&nbsp; Even
         though Wiles was exceptionally well established as a mathematician, he hesitated
         to state publicly what he was working on.&nbsp; Not because he thought his


### PR DESCRIPTION
Some of these are typos, and others are minor HTML syntax fixes found by validation. The `<var>` change is semantic and should not change the rendering.

 - Fix Andrew Wiles' first name.
 - Fix spacing around two links.
 - Fix list markup.
 - Use <var> for n.
 - Standardize hyphenation.
 - Merge anchors into headers.